### PR TITLE
Make Interval a class template

### DIFF
--- a/include/core/AnimatedTransformation.hpp
+++ b/include/core/AnimatedTransformation.hpp
@@ -49,7 +49,7 @@ namespace idragnev::pbrt {
 
         static void intervalFindZeros(const Coefficients& cs,
                                       const Float theta,
-                                      const Interval& tInterval,
+                                      const Intervalf& tInterval,
                                       Float zeros[8],
                                       unsigned& zerosCount,
                                       int depth = 8);

--- a/include/core/Bounds3.hpp
+++ b/include/core/Bounds3.hpp
@@ -23,7 +23,7 @@ namespace idragnev::pbrt {
         template <typename U>
         explicit operator Bounds3<U>() const;
 
-        std::optional<Interval> intersectP(const Ray& ray) const noexcept;
+        std::optional<Intervalf> intersectP(const Ray& ray) const noexcept;
         bool intersectP(const Ray& ray,
                         const Vector3f& invDir,
                         const std::size_t dirIsNeg[3]) const noexcept;

--- a/include/core/Bounds3Impl.hpp
+++ b/include/core/Bounds3Impl.hpp
@@ -31,7 +31,7 @@ namespace idragnev::pbrt {
     }
 
     template <typename T>
-    std::optional<Interval>
+    std::optional<Intervalf>
     Bounds3<T>::intersectP(const Ray& ray) const noexcept {
         Float t0 = 0.f;
         Float t1 = ray.tMax;
@@ -55,7 +55,7 @@ namespace idragnev::pbrt {
             }
         }
 
-        return std::make_optional(Interval{t0, t1});
+        return std::make_optional(Intervalf{t0, t1});
     }
 
     template <typename T>

--- a/include/core/EFloat.hpp
+++ b/include/core/EFloat.hpp
@@ -12,6 +12,8 @@ namespace idragnev::pbrt {
         friend EFloat abs(const EFloat& fe);
         friend EFloat sqrt(const EFloat& fe);
 
+        using ErrBounds = Interval<float>;
+
     public:
         EFloat() = default;
         EFloat(const float v, const float err = 0.f) noexcept;
@@ -51,7 +53,7 @@ namespace idragnev::pbrt {
 
     private:
         float v = 0.f;
-        Interval bounds = {0.f, 0.f, Interval::NoOrderCheck{}};
+        ErrBounds bounds = {0.f, 0.f, NoOrderCheck{}};
 
 #ifndef NDEBUG
         long double vPrecise = 0.;

--- a/include/core/Interval.hpp
+++ b/include/core/Interval.hpp
@@ -2,51 +2,79 @@
 
 #include "core.hpp"
 
+#include <algorithm>
+
 namespace idragnev::pbrt {
+    struct NoOrderCheck
+    {
+    };
+
+    template <typename T>
     class Interval
     {
-    public:
-        struct NoOrderCheck
-        {
-        };
+        static_assert(std::is_arithmetic_v<T>,
+                      "Cannot instantiate Interval with non-arithmetic type");
 
-        Interval(const Float x) noexcept : _low(x), _high(x) {}
-        Interval(const Float a, const Float b) noexcept;
-        Interval(const Float a, const Float b, const NoOrderCheck) noexcept
+    public:
+        Interval(const T x) noexcept : _low(x), _high(x) {}
+        Interval(const T a, const T b) noexcept
+            : _low(std::min(a, b))
+            , _high(std::max(a, b)) {}
+        Interval(const T a, const T b, const NoOrderCheck) noexcept
             : _low(a)
             , _high(b) {}
 
-        Float low() const noexcept { return _low; }
-        Float high() const noexcept { return _high; }
+        T low() const noexcept { return _low; }
+        T high() const noexcept { return _high; }
 
-        Interval withLow(const Float low) const noexcept {
+        Interval withLow(const T low) const noexcept {
             return Interval{low, _high};
         }
-        Interval withHigh(const Float high) const noexcept {
+        Interval withHigh(const T high) const noexcept {
             return Interval{_low, high};
         }
 
     private:
-        Float _low;
-        Float _high;
+        T _low;
+        T _high;
     };
 
-    Interval operator*(const Interval& lhs, const Interval& rhs) noexcept;
+    template <typename T>
+    Interval<T> operator*(const Interval<T>& lhs,
+                          const Interval<T>& rhs) noexcept {
+        // clang-format off
+        const auto [min, max] = std::minmax({
+                lhs.low()  * rhs.low(),
+                lhs.low()  * rhs.high(),
+                lhs.high() * rhs.low(),
+                lhs.high() * rhs.high()
+        });
+        // clang-format on
 
-    inline Interval operator-(const Interval& i) noexcept {
-        return Interval{-i.high(), -i.low(), Interval::NoOrderCheck{}};
+        return Interval<T>{min, max, NoOrderCheck{}};
     }
 
-    inline Interval operator+(const Interval& lhs,
-                              const Interval& rhs) noexcept {
-        return Interval{lhs.low() + rhs.low(), lhs.high() + rhs.high()};
+    template <typename T>
+    inline Interval<T> operator-(const Interval<T>& i) noexcept {
+        return Interval<T>{-i.high(), -i.low(), NoOrderCheck{}};
     }
 
-    inline Interval operator-(const Interval& lhs,
-                              const Interval& rhs) noexcept {
-        return Interval{lhs.low() - rhs.high(), lhs.high() - rhs.low()};
+    template <typename T>
+    inline Interval<T> operator+(const Interval<T>& lhs,
+                                 const Interval<T>& rhs) noexcept {
+        return Interval<T>{lhs.low() + rhs.low(),
+                           lhs.high() + rhs.high(),
+                           NoOrderCheck{}};
     }
 
-    Interval sin(const Interval& i);
-    Interval cos(const Interval& i);
+    template <typename T>
+    inline Interval<T> operator-(const Interval<T>& lhs,
+                                 const Interval<T>& rhs) noexcept {
+        return Interval<T>{lhs.low() - rhs.high(),
+                           lhs.high() - rhs.low(),
+                           NoOrderCheck{}};
+    }
+
+    Intervalf sin(const Intervalf& i);
+    Intervalf cos(const Intervalf& i);
 } // namespace idragnev::pbrt

--- a/include/core/core.hpp
+++ b/include/core/core.hpp
@@ -84,7 +84,10 @@ namespace idragnev::pbrt {
     struct TRS;
     class AnimatedTransformation;
 
+    template <typename T>
     class Interval;
+
+    using Intervalf = Interval<Float>;
 
     class Interaction;
     class SurfaceInteraction;

--- a/src/core/AnimatedTransformation.cpp
+++ b/src/core/AnimatedTransformation.cpp
@@ -783,7 +783,7 @@ namespace idragnev::pbrt {
 
         const auto cosTheta = dot(startTRS.R, endTRS.R);
         const auto theta = std::acos(clamp(cosTheta, -1.f, 1.f));
-        const auto tInterval = Interval{0.f, 1.f};
+        const auto tInterval = Intervalf{0.f, 1.f};
 
         auto bounds = Bounds3f{(*startTransform)(p), (*endTransform)(p)};
         for (std::size_t c = 0; c < 3; ++c) {
@@ -807,15 +807,15 @@ namespace idragnev::pbrt {
 
     void AnimatedTransformation::intervalFindZeros(const Coefficients& cs,
                                                    const Float theta,
-                                                   const Interval& tInterval,
+                                                   const Intervalf& tInterval,
                                                    Float zeros[8],
                                                    unsigned& zerosCount,
                                                    int depth) {
-        const auto range = Interval{cs.c1} +
-                           (Interval{cs.c2} + Interval{cs.c3} * tInterval) *
-                               cos(Interval{2.f * theta} * tInterval) +
-                           (Interval{cs.c4} + Interval{cs.c5} * tInterval) *
-                               sin(Interval{2.f * theta} * tInterval);
+        const auto range = Intervalf{cs.c1} +
+                           (Intervalf{cs.c2} + Intervalf{cs.c3} * tInterval) *
+                               cos(Intervalf{2.f * theta} * tInterval) +
+                           (Intervalf{cs.c4} + Intervalf{cs.c5} * tInterval) *
+                               sin(Intervalf{2.f * theta} * tInterval);
         if (range.low() > 0.f || range.high() < 0.f ||
             range.low() == range.high()) {
             return;

--- a/src/core/EFloat.cpp
+++ b/src/core/EFloat.cpp
@@ -7,10 +7,10 @@ namespace idragnev::pbrt {
     EFloat::EFloat(const float v, const float err) noexcept
         : v(v)
         , bounds([err, v] {
-            return err == 0.f ? Interval{v}
-                              : Interval{nextFloatDown(v - err),
-                                         nextFloatUp(v + err),
-                                         Interval::NoOrderCheck{}};
+            return err == 0.f ? ErrBounds{v}
+                              : ErrBounds{nextFloatDown(v - err),
+                                          nextFloatUp(v + err),
+                                          NoOrderCheck{}};
         }())
 #ifndef NDEBUG
         , vPrecise(v)
@@ -42,9 +42,9 @@ namespace idragnev::pbrt {
         result.v = v + rhs.v;
 
         const auto b = bounds + rhs.bounds;
-        result.bounds = Interval{nextFloatDown(b.low()),
-                                 nextFloatUp(b.high()),
-                                 Interval::NoOrderCheck{}};
+        result.bounds = ErrBounds{nextFloatDown(b.low()),
+                                  nextFloatUp(b.high()),
+                                  NoOrderCheck{}};
 
 #ifndef NDEBUG
         result.vPrecise = vPrecise + rhs.vPrecise;
@@ -64,9 +64,9 @@ namespace idragnev::pbrt {
 #endif //! NDEBUG
 
         if (rhs.lowerBound() < 0.f && rhs.upperBound() > 0.f) {
-            result.bounds = Interval{-constants::Infinity,
-                                     constants::Infinity,
-                                     Interval::NoOrderCheck{}};
+            result.bounds = ErrBounds{-constants::Infinity,
+                                      constants::Infinity,
+                                      NoOrderCheck{}};
         }
         else {
             const auto [min, max] =
@@ -74,9 +74,8 @@ namespace idragnev::pbrt {
                              lowerBound() / rhs.upperBound(),
                              upperBound() / rhs.lowerBound(),
                              upperBound() / rhs.upperBound()});
-            result.bounds = Interval{nextFloatDown(min),
-                                     nextFloatUp(max),
-                                     Interval::NoOrderCheck{}};
+            result.bounds =
+                ErrBounds{nextFloatDown(min), nextFloatUp(max), NoOrderCheck{}};
         }
 
         return result;
@@ -88,9 +87,9 @@ namespace idragnev::pbrt {
         result.v = v * rhs.v;
 
         const auto b = bounds * rhs.bounds;
-        result.bounds = Interval{nextFloatDown(b.low()),
-                                 nextFloatUp(b.high()),
-                                 Interval::NoOrderCheck{}};
+        result.bounds = ErrBounds{nextFloatDown(b.low()),
+                                  nextFloatUp(b.high()),
+                                  NoOrderCheck{}};
 
 #ifndef NDEBUG
         result.vPrecise = vPrecise * rhs.vPrecise;
@@ -105,9 +104,9 @@ namespace idragnev::pbrt {
         result.v = v - rhs.v;
 
         const auto b = bounds - rhs.bounds;
-        result.bounds = Interval{nextFloatDown(b.low()),
-                                 nextFloatUp(b.high()),
-                                 Interval::NoOrderCheck{}};
+        result.bounds = ErrBounds{nextFloatDown(b.low()),
+                                  nextFloatUp(b.high()),
+                                  NoOrderCheck{}};
 
 #ifndef NDEBUG
         result.vPrecise = vPrecise - rhs.vPrecise;
@@ -129,9 +128,10 @@ namespace idragnev::pbrt {
 
         assert(ef.lowerBound() >= 0.f);
         assert(ef.upperBound() >= 0.f);
-        result.bounds = Interval{nextFloatDown(std::sqrt(ef.lowerBound())),
-                                 nextFloatUp(std::sqrt(ef.upperBound())),
-                                 Interval::NoOrderCheck{}};
+        result.bounds =
+            EFloat::ErrBounds{nextFloatDown(std::sqrt(ef.lowerBound())),
+                              nextFloatUp(std::sqrt(ef.upperBound())),
+                              NoOrderCheck{}};
 
         return result;
     }
@@ -148,9 +148,9 @@ namespace idragnev::pbrt {
 
             result.v = std::abs(ef.v);
             result.bounds =
-                Interval{0.f,
-                         std::max(-ef.lowerBound(), ef.upperBound()),
-                         Interval::NoOrderCheck{}};
+                EFloat::ErrBounds{0.f,
+                                  std::max(-ef.lowerBound(), ef.upperBound()),
+                                  NoOrderCheck{}};
 
 #ifndef NDEBUG
             result.vPrecise = std::abs(ef.vPrecise);

--- a/src/core/Interval.cpp
+++ b/src/core/Interval.cpp
@@ -4,24 +4,7 @@
 #include <assert.h>
 
 namespace idragnev::pbrt {
-    Interval::Interval(const Float a, const Float b) noexcept
-        : _low(std::min(a, b))
-        , _high(std::max(a, b)) {}
-
-    Interval operator*(const Interval& lhs, const Interval& rhs) noexcept {
-        // clang-format off
-        const auto [min, max] = std::minmax({
-                lhs.low()  * rhs.low(),
-                lhs.low()  * rhs.high(),
-                lhs.high() * rhs.low(),
-                lhs.high() * rhs.high()
-        });
-        // clang-format on
-
-        return Interval{min, max};
-    }
-
-    Interval sin(const Interval& i) {
+    Intervalf sin(const Intervalf& i) {
         using constants::Pi;
         using constants::PiOver2;
 
@@ -43,10 +26,10 @@ namespace idragnev::pbrt {
             sinLow = -1.f;
         }
 
-        return Interval{sinLow, sinHigh};
+        return Intervalf{sinLow, sinHigh};
     }
 
-    Interval cos(const Interval& i) {
+    Intervalf cos(const Intervalf& i) {
         using constants::Pi;
         using constants::PiOver2;
 
@@ -63,6 +46,6 @@ namespace idragnev::pbrt {
             cosLow = -1.f;
         }
 
-        return Interval{cosLow, cosHigh};
+        return Intervalf{cosLow, cosHigh};
     }
 } // namespace idragnev::pbrt

--- a/tests/core/interval.cpp
+++ b/tests/core/interval.cpp
@@ -5,8 +5,8 @@ namespace pbrt = idragnev::pbrt;
 
 TEST_CASE("construction from two values does not depend on"
           "arguments order") {
-    const auto i1 = pbrt::Interval{1.f, 0.f};
-    const auto i2 = pbrt::Interval{0.f, 1.f};
+    const auto i1 = pbrt::Intervalf{1.f, 0.f};
+    const auto i2 = pbrt::Intervalf{0.f, 1.f};
 
     CHECK(i1.low() == 0.f);
     CHECK(i1.high() == 1.f);
@@ -16,8 +16,8 @@ TEST_CASE("construction from two values does not depend on"
 }
 
 TEST_CASE("multiplication") {
-    const auto a = pbrt::Interval{0.f, 5.f};
-    const auto b = pbrt::Interval{2.f, 10.f};
+    const auto a = pbrt::Intervalf{0.f, 5.f};
+    const auto b = pbrt::Intervalf{2.f, 10.f};
 
     const auto c = a * b;
 
@@ -26,8 +26,8 @@ TEST_CASE("multiplication") {
 }
 
 TEST_CASE("sum") {
-    const auto a = pbrt::Interval{0.f, 5.f};
-    const auto b = pbrt::Interval{2.f, 10.f};
+    const auto a = pbrt::Intervalf{0.f, 5.f};
+    const auto b = pbrt::Intervalf{2.f, 10.f};
 
     const auto c = a + b;
 
@@ -36,8 +36,8 @@ TEST_CASE("sum") {
 }
 
 TEST_CASE("subtraction") {
-    const auto a = pbrt::Interval{0.f, 5.f};
-    const auto b = pbrt::Interval{2.f, 10.f};
+    const auto a = pbrt::Intervalf{0.f, 5.f};
+    const auto b = pbrt::Intervalf{2.f, 10.f};
 
     const auto c = a - b;
 
@@ -46,7 +46,7 @@ TEST_CASE("subtraction") {
 }
 
 TEST_CASE("negation") {
-    const auto a = pbrt::Interval{2.f, 10.f};
+    const auto a = pbrt::Intervalf{2.f, 10.f};
 
     const auto b = -a;
 
@@ -55,7 +55,7 @@ TEST_CASE("negation") {
 }
 
 TEST_CASE("withLow") {
-    const auto interval = pbrt::Interval{0.f, 3.f};
+    const auto interval = pbrt::Intervalf{0.f, 3.f};
 
     SUBCASE("with higher argument than high") {
         const auto i = interval.withLow(4.f);
@@ -73,7 +73,7 @@ TEST_CASE("withLow") {
 }
 
 TEST_CASE("withHigh") {
-    const auto interval = pbrt::Interval{0.f, 3.f};
+    const auto interval = pbrt::Intervalf{0.f, 3.f};
 
     SUBCASE("with higher argument than high") {
         const auto i = interval.withHigh(4.f);


### PR DESCRIPTION
Made `Interval` a class template templated on its underlying type. This
was needed because `EFloat` uses it for the error bounds but with `float`
as the underlying type (this was missed when implementing `EFloat`).
All current clients of `Interval` (except for `EFloat`) were changed to use
`Intervalf` - a new type alias for `Interval<Float>`.