### PR TITLE
doctest as a CMake dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/doctest"]
-	path = external/doctest
-	url = https://github.com/onqtam/doctest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,12 @@ if(NOT tl_optional_POPULATED)
   add_subdirectory(${tl_optional_SOURCE_DIR} ${tl_optional_BINARY_DIR})
 endif()
 
+FetchContent_Declare(doctest
+  GIT_REPOSITORY https://github.com/onqtam/doctest.git
+  GIT_TAG        2.4.3
+)
+FetchContent_MakeAvailable(doctest)
+
 # PBRT targets
 add_subdirectory(src/functional)
 add_subdirectory(src/parallel)
@@ -53,7 +59,6 @@ add_subdirectory(src/memory)
 add_subdirectory(src/shapes)
 add_subdirectory(src/accelerators)
 add_subdirectory(app)
-add_subdirectory(external/doctest)
 add_subdirectory(tests/core)
 add_subdirectory(tests/memory)
 add_subdirectory(tests/functional)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.14)
 
 project(ray-tracer
   LANGUAGES CXX

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ The project is regularly built with:
  - GCC 10.2
  - GCC 9.3 (less often)  
 
+**CMake 3.14 or higher**.  
 Note that **the warning level is set to Error for CMake builds**,  
 so builds may fail because of a warning with other compiler versions.  
 
 CMake options:
  - PBRT_FLOAT_AS_DOUBLE - use 64-bit floats (off by default)
- 
-Example (build with 64-bit floats):  
+
+Example:  
  ```
- $ git clone --recursive https://github.com/IDragnev/pb-ray-tracer.git  
+ # build with 64-bit floats
+ $ git clone https://github.com/IDragnev/pb-ray-tracer.git  
  $ cd pb-ray-tracer  
  $ mkdir build && cd build  
  $ cmake -D PBRT_FLOAT_AS_DOUBLE=ON ..  


### PR DESCRIPTION
- Removed the `doctest` git submodule.
- Made `doctest` a CMake dependency.
- Bumped the CMake minimum version to 3.14 in order to use the clean `FetchContent_MakeAvailable`.